### PR TITLE
chore: setup access logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "esbuild": "^0.17.19",
     "esbuild-register": "^3.4.2",
     "express": "^4.18.2",
+    "hono": "^3.2.0",
     "nodemon": "^2.0.22",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ devDependencies:
   express:
     specifier: ^4.18.2
     version: 4.18.2
+  hono:
+    specifier: ^3.2.0
+    version: 3.2.0
   nodemon:
     specifier: ^2.0.22
     version: 2.0.22
@@ -1781,6 +1784,11 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+    dev: true
+
+  /hono@3.2.0:
+    resolution: {integrity: sha512-dsPameDZC+VYainhDxUnuYRFUytpLBN9CF1QjrtPx7AtlOaNLMKc5pKsZF1dnPmGal/QaM9YDAEnzZLUJ1ugsA==}
+    engines: {node: '>=16.0.0'}
     dev: true
 
   /hosted-git-info@2.8.9:

--- a/src/server/entry-dev.ts
+++ b/src/server/entry-dev.ts
@@ -2,7 +2,7 @@ import { createServer } from "node:http";
 import { createMiddleware } from "@hattip/adapter-node";
 import express from "express";
 import vite from "vite";
-import { hattipApp } from "./hattip";
+import { createHattipApp } from "./hattip";
 import { listenPortSearchByEnv } from "./http";
 
 // cf. https://github.com/sapphi-red/vite-setup-catalogue/blob/48cde75352005aa1c1780f5eccf022db5619e285/examples/middleware-mode/server.js
@@ -18,7 +18,7 @@ async function main() {
   app.use(viteServer.middlewares);
 
   // all application logic as hattip handler
-  app.use(createMiddleware(hattipApp));
+  app.use(createMiddleware(createHattipApp()));
 
   // start app
   const port = await listenPortSearchByEnv(server);

--- a/src/server/entry-preview.ts
+++ b/src/server/entry-preview.ts
@@ -1,7 +1,7 @@
 import { createServer } from "node:http";
 import { createMiddleware } from "@hattip/adapter-node";
 import express from "express";
-import { hattipApp } from "./hattip";
+import { createHattipApp } from "./hattip";
 import { listenPortSearchByEnv } from "./http";
 
 // test production build locally with express
@@ -16,7 +16,7 @@ async function main() {
   app.use(express.static(`./dist/client`));
 
   // application logic
-  app.use(createMiddleware(hattipApp));
+  app.use(createMiddleware(createHattipApp()));
 
   // start app
   const port = await listenPortSearchByEnv(server);

--- a/src/server/entry-vercel.ts
+++ b/src/server/entry-vercel.ts
@@ -1,6 +1,12 @@
 import { createMiddleware } from "@hattip/adapter-node";
-import { hattipApp } from "./hattip";
+import { createHattipApp } from "./hattip";
 
 // cf. https://github.com/hattipjs/hattip/blob/03a704fa120dfe2eddd6cf22eff00c90bda2acb5/packages/bundler/bundler-vercel/readme.md
 
-export default createMiddleware(hattipApp, { trustProxy: true });
+export default createVercelHanlder();
+
+function createVercelHanlder() {
+  return createMiddleware(createHattipApp({ noLogger: true }), {
+    trustProxy: true,
+  });
+}

--- a/src/server/hattip.ts
+++ b/src/server/hattip.ts
@@ -1,4 +1,5 @@
 import { type RequestHandler, compose } from "@hattip/compose";
+import { typedBoolean } from "@hiogawa/utils";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { logger } from "hono/logger";
 import { renderPage } from "vite-plugin-ssr/server";
@@ -61,8 +62,12 @@ function createHattipLogger() {
   return hattipLogger;
 }
 
-export const hattipApp = compose(
-  createHattipLogger(),
-  hattipTrpc,
-  hattipVitePluginSsr
-);
+export function createHattipApp(options?: { noLogger?: boolean }) {
+  const handlers = [
+    !options?.noLogger && createHattipLogger(),
+    hattipTrpc,
+    hattipVitePluginSsr,
+  ].filter(typedBoolean);
+
+  return compose(handlers);
+}

--- a/src/server/hattip.ts
+++ b/src/server/hattip.ts
@@ -1,5 +1,6 @@
 import { type RequestHandler, compose } from "@hattip/compose";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { logger } from "hono/logger";
 import { renderPage } from "vite-plugin-ssr/server";
 import { TRPC_ENDPOINT } from "../trpc/common";
 import { trpcRoot } from "../trpc/server";
@@ -36,4 +37,32 @@ const hattipTrpc: RequestHandler = (ctx) => {
   });
 };
 
-export const hattipApp = compose(hattipTrpc, hattipVitePluginSsr);
+function createHattipLogger() {
+  // borrow hono's logger with minimal compatibility hack
+  // https://github.com/honojs/hono/blob/0ffd795ec6cfb67d38ab902197bb5461a4740b8f/src/middleware/logger/index.ts
+  const honoLogger = logger();
+
+  const hattipLogger: RequestHandler = async (ctx) => {
+    let hattipRes!: Response;
+    const honoNext = async () => {
+      hattipRes = await ctx.next();
+    };
+    const honoReq = { method: ctx.method, raw: ctx.request };
+    const honoRes = {
+      get status() {
+        return hattipRes.status;
+      },
+    };
+    const honoCtx = { req: honoReq, res: honoRes };
+    await honoLogger(honoCtx as any, honoNext as any);
+    return hattipRes;
+  };
+
+  return hattipLogger;
+}
+
+export const hattipApp = compose(
+  createHattipLogger(),
+  hattipTrpc,
+  hattipVitePluginSsr
+);


### PR DESCRIPTION
Borrowing Hono's logger middleware by adding sketchy compatibility later with hattip.

```sh
$ pnpm dev
...

[entry-dev] Server running at http://localhost:3456

  <-- GET /trpc
  --> GET /trpc 200 206ms
  <-- GET /_trpc/getCounter
  --> GET /_trpc/getCounter 200 2ms
  <-- POST /_trpc/updateCounter
  --> POST /_trpc/updateCounter 200 2ms
  <-- GET /_trpc/getCounter
  --> GET /_trpc/getCounter 200 0ms
```