### PR TITLE
feat: persist counter in redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # https://vercel.com/docs/storage/vercel-kv
-APP_REDIS_URL=redis://xxx:yyy@zzz.kv.vercel-storage.com:12345
+APP_REDIS_URL=rediss://xxx:yyy@zzz.kv.vercel-storage.com:12345
 APP_REDIS_PREFIX=production

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# https://vercel.com/docs/storage/vercel-kv
+APP_REDIS_URL=redis://xxx:yyy@zzz.kv.vercel-storage.com:12345
+APP_REDIS_PREFIX=production

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 .vercel
+.env.staging
+.env.production

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 .PHONY: $(shell grep --no-filename -E '^([a-zA-Z_-]|/)+:' $(MAKEFILE_LIST) | sed 's/:.*//')
 
 docker/up:
-	docker-compose up -d
-	docker-compose run --rm dockerize -wait tcp://redis:6379
+	docker compose up -d
+	docker compose run --rm dockerize -wait tcp://redis:6379
 
 docker/down:
-	docker-compose down
+	docker compose down
 
 docker/clean:
-	docker-compose down -v --remove-orphans
-	docker-compose rm -f -s -v
+	docker compose down -v --remove-orphans
+	docker compose rm -f -s -v

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# everything phony
+.PHONY: $(shell grep --no-filename -E '^([a-zA-Z_-]|/)+:' $(MAKEFILE_LIST) | sed 's/:.*//')
+
+docker/up:
+	docker-compose up -d
+	docker-compose run --rm dockerize -wait tcp://redis:6379
+
+docker/down:
+	docker-compose down
+
+docker/clean:
+	docker-compose down -v --remove-orphans
+	docker-compose rm -f -s -v
+
+redis/reset: redis/reset/dev redis/reset/test
+
+redis/reset/dev:
+
+redis/reset/test:

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,3 @@ docker/down:
 docker/clean:
 	docker-compose down -v --remove-orphans
 	docker-compose rm -f -s -v
-
-redis/reset: redis/reset/dev redis/reset/test
-
-redis/reset/dev:
-
-redis/reset/test:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 ```sh
 # development
+make docker/up redis/reset
 pnpm i
 pnpm dev
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 - api
   - trpc
   - tanstack query
+- persistence
+  - redis
 - deployment
-  - vercel serverless, cdn
+  - vercel serverless, kv, cdn
 
 ## usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.5"
+
+services:
+  redis:
+    image: redis:7.0.11-alpine
+    ports:
+      - 6379:6379
+    volumes:
+      - redis-volume:/data
+
+  dockerize:
+    image: jwilder/dockerize:0.6.1
+    profiles: ["tools"]
+
+volumes:
+  redis-volume:

--- a/misc/dot-env.sh
+++ b/misc/dot-env.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# based on https://stackoverflow.com/questions/19331497/set-environment-variables-from-file-of-key-value-pairs
+
+# usage:
+#   bash misc/dot-env.sh [dot-env-file] [command...]
+
+dot_env_file="$1"
+shift
+
+# shellcheck disable=SC2046
+env $(grep -v '^#' "$dot_env_file") "${@}"

--- a/misc/vercel/copy-env.sh
+++ b/misc/vercel/copy-env.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eu -o pipefail
+
+# usage:
+#   bash misc/dot-env.sh .env.staging bash misc/vercel/copy-env.sh preview APP_REDIS_URL APP_REDIS_PREFIX
+#   bash misc/dot-env.sh .env.production bash misc/vercel/copy-env.sh production APP_REDIS_URL APP_REDIS_PREFIX
+
+target="$1"
+shift
+
+for key in "${@}"; do
+  value="${!key:-}"
+  if [ -z "${NO_CONFIRM:-}" ]; then
+    echo ":: proceed to set '$key'? (y/n)"
+    echo "$key=$value"
+    read -n 1 -r
+    echo
+    case "$REPLY" in
+      y) ;;
+      *)
+        echo "skipped ($key)"
+        continue
+      ;;
+    esac
+  fi
+  echo 'y' | vercel env rm "$key" "$target" || true
+  echo -n "$value" | vercel env add "$key" "$target"
+done

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "esbuild-register": "^3.4.2",
     "express": "^4.18.2",
     "hono": "^3.2.0",
+    "ioredis": "^5.3.2",
     "nodemon": "^2.0.22",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -4,7 +4,7 @@ export function Page() {
   const [value, setValue] = React.useState(0);
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 w-lg">
       <h2 className="text-lg">Client State</h2>
       <div>counter: {value}</div>
       <div className="flex items-center gap-2">

--- a/pages/trpc.page.tsx
+++ b/pages/trpc.page.tsx
@@ -1,15 +1,17 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "react-hot-toast";
 import { trpcRQ } from "../src/trpc/react-query";
 
 export function Page() {
-  const counterQuery = useQuery(trpcRQ.getCounter.queryOptions());
+  const counterQueryOptions = trpcRQ.getCounter.queryOptions();
+  const counterQuery = useQuery(counterQueryOptions);
 
+  const queryClient = useQueryClient();
   const counterMutation = useMutation({
     ...trpcRQ.updateCounter.mutationOptions(),
-    onSuccess: () => {
-      toast.success("Successfully updated");
-      counterQuery.refetch();
+    onSuccess: (data) => {
+      toast.success("Successfully updated", { id: "counter-mutation-success" });
+      queryClient.setQueryData(counterQueryOptions.queryKey, data);
     },
   });
 

--- a/pages/trpc.page.tsx
+++ b/pages/trpc.page.tsx
@@ -15,19 +15,26 @@ export function Page() {
     },
   });
 
+  const loading = counterQuery.isFetching || counterMutation.isLoading;
+
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 w-lg">
       <h2 className="text-lg">Server State</h2>
-      <div>counter = {counterQuery.isFetching ? "..." : counterQuery.data}</div>
+      <div className="flex items-center gap-3">
+        <span>counter = {counterQuery.data ?? "..."}</span>
+        {loading && <div className="antd-spin w-4 h-4"></div>}
+      </div>
       <div className="flex items-center gap-2">
         <button
           className="antd-btn antd-btn-default px-2"
+          disabled={loading}
           onClick={() => counterMutation.mutate({ delta: -1 })}
         >
           -1
         </button>
         <button
           className="antd-btn antd-btn-default px-2"
+          disabled={loading}
           onClick={() => counterMutation.mutate({ delta: +1 })}
         >
           +1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ devDependencies:
   hono:
     specifier: ^3.2.0
     version: 3.2.0
+  ioredis:
+    specifier: ^5.3.2
+    version: 5.3.2
   nodemon:
     specifier: ^2.0.22
     version: 2.0.22
@@ -653,6 +656,10 @@ packages:
       - supports-color
     dev: true
 
+  /@ioredis/commands@1.2.0:
+    resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
+    dev: true
+
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -1233,6 +1240,11 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
@@ -1368,6 +1380,11 @@ packages:
 
   /defu@6.1.2:
     resolution: {integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==}
+    dev: true
+
+  /denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
     dev: true
 
   /depd@2.0.0:
@@ -1835,6 +1852,23 @@ packages:
       side-channel: 1.0.4
     dev: true
 
+  /ioredis@5.3.2:
+    resolution: {integrity: sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      '@ioredis/commands': 1.2.0
+      cluster-key-slot: 1.1.2
+      debug: 4.3.4
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -2028,6 +2062,14 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
+    dev: true
+
+  /lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    dev: true
+
+  /lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
     dev: true
 
   /loose-envify@1.4.0:
@@ -2451,6 +2493,18 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+    dependencies:
+      redis-errors: 1.2.0
+    dev: true
+
   /regexp.prototype.flags@1.5.0:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
@@ -2647,6 +2701,10 @@ packages:
 
   /spdx-license-ids@3.0.13:
     resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==}
+    dev: true
+
+  /standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
     dev: true
 
   /statuses@2.0.1:

--- a/src/server/hattip.ts
+++ b/src/server/hattip.ts
@@ -5,6 +5,7 @@ import { logger } from "hono/logger";
 import { renderPage } from "vite-plugin-ssr/server";
 import { TRPC_ENDPOINT } from "../trpc/common";
 import { trpcRoot } from "../trpc/server";
+import { hattipBootstrapHandler } from "../utils/bootstrap";
 
 const hattipVitePluginSsr: RequestHandler = async (ctx) => {
   const pageContext = await renderPage({ urlOriginal: ctx.request.url });
@@ -64,6 +65,7 @@ function createHattipLogger() {
 
 export function createHattipApp(options?: { noLogger?: boolean }) {
   const handlers = [
+    hattipBootstrapHandler,
     !options?.noLogger && createHattipLogger(),
     hattipTrpc,
     hattipVitePluginSsr,

--- a/src/trpc/server.ts
+++ b/src/trpc/server.ts
@@ -1,13 +1,13 @@
+import process from "node:process";
 import { z } from "zod";
+import { redis } from "../utils/redis-utils";
 import { trpcProcedureBuilder, trpcRouterFactory } from "./factory";
-
-let counter = 0;
 
 export const trpcRoot = trpcRouterFactory({
   _healthz: trpcProcedureBuilder.query(() => ({ ok: true })),
 
   getCounter: trpcProcedureBuilder.query(() => {
-    return counter;
+    return udpateCounter(0);
   }),
 
   updateCounter: trpcProcedureBuilder
@@ -17,6 +17,17 @@ export const trpcRoot = trpcRouterFactory({
       })
     )
     .mutation(({ input }) => {
-      counter += input.delta;
+      return udpateCounter(input.delta);
     }),
 });
+
+//
+// redis counter
+//
+
+const PREFIX = process.env["NODE_ENV"] ?? "development";
+const COUNTER_KEY = `${PREFIX}:counter`;
+
+function udpateCounter(delta: number): Promise<number> {
+  return redis.incrby(COUNTER_KEY, delta);
+}

--- a/src/trpc/server.ts
+++ b/src/trpc/server.ts
@@ -1,5 +1,5 @@
-import process from "node:process";
 import { z } from "zod";
+import { serverConfig } from "../utils/config";
 import { redis } from "../utils/redis-utils";
 import { trpcProcedureBuilder, trpcRouterFactory } from "./factory";
 
@@ -25,9 +25,7 @@ export const trpcRoot = trpcRouterFactory({
 // redis counter
 //
 
-const PREFIX = process.env["NODE_ENV"] ?? "development";
-const COUNTER_KEY = `${PREFIX}:counter`;
-
 function udpateCounter(delta: number): Promise<number> {
-  return redis.incrby(COUNTER_KEY, delta);
+  const key = `${serverConfig.APP_REDIS_PREFIX}:counter`;
+  return redis.incrby(key, delta);
 }

--- a/src/utils/bootstrap.tsx
+++ b/src/utils/bootstrap.tsx
@@ -1,8 +1,12 @@
 import type { RequestHandler } from "@hattip/compose";
 import { once } from "@hiogawa/utils";
+import { initializeConfig } from "./config";
 import { initializeRedis } from "./redis-utils";
 
+// initialize globals
+
 export async function bootstrap() {
+  initializeConfig();
   await initializeRedis();
 }
 

--- a/src/utils/bootstrap.tsx
+++ b/src/utils/bootstrap.tsx
@@ -1,0 +1,14 @@
+import type { RequestHandler } from "@hattip/compose";
+import { once } from "@hiogawa/utils";
+import { initializeRedis } from "./redis-utils";
+
+export async function bootstrap() {
+  await initializeRedis();
+}
+
+const bootstrapOnce = once(bootstrap);
+
+export const hattipBootstrapHandler: RequestHandler = async (ctx) => {
+  await bootstrapOnce();
+  return ctx.next();
+};

--- a/src/utils/config.tsx
+++ b/src/utils/config.tsx
@@ -1,0 +1,15 @@
+import process from "node:process";
+import { z } from "zod";
+
+const Z_SERVER_CONFIG = z.object({
+  APP_REDIS_URL: z.string().default("redis://localhost:6379"),
+  APP_REDIS_PREFIX: z.string().default("dev"),
+});
+
+type ServerConfig = z.infer<typeof Z_SERVER_CONFIG>;
+
+export let serverConfig: ServerConfig;
+
+export function initializeConfig() {
+  serverConfig = Z_SERVER_CONFIG.parse(process.env);
+}

--- a/src/utils/config.tsx
+++ b/src/utils/config.tsx
@@ -2,7 +2,8 @@ import process from "node:process";
 import { z } from "zod";
 
 const Z_SERVER_CONFIG = z.object({
-  APP_REDIS_URL: z.string().default("redis://localhost:6379"),
+  APP_REDIS_URL: z.string().default("redis://localhost:6379/0"),
+  // manage prefix manually to (ab)use single upstash redis for staging and production
   APP_REDIS_PREFIX: z.string().default("dev"),
 });
 

--- a/src/utils/redis-utils.ts
+++ b/src/utils/redis-utils.ts
@@ -1,10 +1,12 @@
 import { Redis } from "ioredis";
+import { serverConfig } from "./config";
 
 export let redis: Redis;
 
 export async function initializeRedis() {
-  // TODO: configurable
-  const url = "redis://localhost:6379";
-  redis = new Redis(url, { lazyConnect: true, maxRetriesPerRequest: 3 });
+  redis = new Redis(serverConfig.APP_REDIS_URL, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 3,
+  });
   await redis.ping();
 }

--- a/src/utils/redis-utils.ts
+++ b/src/utils/redis-utils.ts
@@ -1,0 +1,10 @@
+import { Redis } from "ioredis";
+
+export let redis: Redis;
+
+export async function initializeRedis() {
+  // TODO: configurable
+  const url = "redis://localhost:6379";
+  redis = new Redis(url, { lazyConnect: true, maxRetriesPerRequest: 3 });
+  await redis.ping();
+}


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-fullstack-example/issues/5

## todo

- [ ] e2e (separate PR) https://github.com/hi-ogawa/vite-fullstack-example/pull/15
- [x] dev https://github.com/luin/ioredis
- [x] release https://vercel.com/docs/storage/vercel-kv
  - note that we have to give `rediss://` (instead of `redis://`) to `ioredis` though vercel doesn't mention in the doc.

```sh
bash misc/dot-env.sh .env.staging bash misc/vercel/copy-env.sh preview APP_REDIS_URL APP_REDIS_PREFIX
bash misc/dot-env.sh .env.production bash misc/vercel/copy-env.sh production APP_REDIS_URL APP_REDIS_PREFIX
```