### PR TITLE
chore: setup client side navigation

### DIFF
--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -15,7 +15,6 @@ test("basic", async ({ page }) => {
 
   await page.getByRole("link", { name: "/trpc" }).click();
   await page.waitForURL("/trpc");
-  await waitForHydration(page);
 
   await page.getByText("counter = 0").click();
   await page.getByRole("button", { name: "+1" }).click();

--- a/renderer/_default.page.client.tsx
+++ b/renderer/_default.page.client.tsx
@@ -1,25 +1,16 @@
 import "virtual:uno.css";
 import { tinyassert } from "@hiogawa/utils";
 import React from "react";
-import { createRoot } from "react-dom/client";
+import { type Root, hydrateRoot } from "react-dom/client";
 import { PAGE_DOM_ID, PageWrapper } from "./common";
+import type { PageClientRender } from "./types";
 
-// TODO: when is it different from PageContextServer?
-// import { PageContextBuiltIn } from "vite-plugin-ssr/types";
-export type PageContextClient = {
-  Page: React.FC;
-  pageProps?: Record<string, unknown>;
-};
+let reactRoot: Root | undefined;
 
-type RenderClient = (pageContext: PageContextClient) => void;
-
-export const render: RenderClient = (ctx) => {
+export const render: PageClientRender = (ctx) => {
   const pageEl = document.getElementById(PAGE_DOM_ID);
   tinyassert(pageEl);
 
-  // TODO: client navigation
-
-  const root = createRoot(pageEl);
   const page = (
     <React.StrictMode>
       <PageWrapper>
@@ -27,5 +18,15 @@ export const render: RenderClient = (ctx) => {
       </PageWrapper>
     </React.StrictMode>
   );
-  root.render(page);
+
+  if (ctx.isHydration) {
+    tinyassert(!reactRoot);
+    reactRoot = hydrateRoot(pageEl, page);
+  } else {
+    tinyassert(reactRoot);
+    reactRoot.render(page);
+  }
 };
+
+// https://vite-plugin-ssr.com/clientRouting
+export const clientRouting = true;

--- a/renderer/_default.page.server.tsx
+++ b/renderer/_default.page.server.tsx
@@ -2,25 +2,11 @@ import THEME_SCRIPT from "@hiogawa/utils-experimental/dist/theme-script.global.j
 import { renderToString } from "react-dom/server";
 import { dangerouslySkipEscape, escapeInject } from "vite-plugin-ssr/server";
 import { PAGE_DOM_ID, PageWrapper } from "./common";
+import type { PageServerRender } from "./types";
 
-// PageContext api is customizable for own need
-// cf.
-// import type { PageContextBuiltIn } from "vite-plugin-ssr/types";
-
-type PageContextServer = {
-  Page: React.FC;
-  pageProps?: Record<string, unknown>;
-};
-
-type RenderServer = (ctx: PageContextServer) => {
-  documentHtml: unknown;
-  pageContext: {}; // TODO?
-};
-
-// TODO: pageProps
 export const passToClient = ["pageProps"];
 
-export const render: RenderServer = (ctx) => {
+export const render: PageServerRender = (ctx) => {
   // TODO: streaming
   const page = (
     <PageWrapper>

--- a/renderer/types.tsx
+++ b/renderer/types.tsx
@@ -1,30 +1,19 @@
 import type React from "react";
+import type { escapeInject } from "vite-plugin-ssr/server";
 import type { PageContextBuiltInClientWithClientRouting } from "vite-plugin-ssr/types";
 
 //
 // page context
 //
 
-export type PageContext = IntersectionReplace<
-  PageContextBuiltInClientWithClientRouting,
-  {
-    Page: React.FC;
+export type PageContext =
+  PageContextBuiltInClientWithClientRouting<React.FC> & {
     pageProps?: Record<string, unknown>;
-  }
->;
+  };
 
 export type PageClientRender = (ctx: PageContext) => void;
 
 export type PageServerRender = (ctx: PageContext) => {
-  documentHtml: unknown;
+  documentHtml: ReturnType<typeof escapeInject>;
   pageContext: {}; // TODO: extra context can be passed to client (e.g. document title)
 };
-
-//
-// utils
-//
-
-// cf. https://github.com/sindresorhus/type-fest/blob/1fce25cf8afadd4d4013e8f0ee64d045eda45cd7/source/except.d.ts
-type StrictOmit<T, K extends keyof T> = Omit<T, K>;
-
-type IntersectionReplace<T1, T2> = StrictOmit<T1, keyof T1 & keyof T2> & T2;

--- a/renderer/types.tsx
+++ b/renderer/types.tsx
@@ -1,0 +1,30 @@
+import type React from "react";
+import type { PageContextBuiltInClientWithClientRouting } from "vite-plugin-ssr/types";
+
+//
+// page context
+//
+
+export type PageContext = IntersectionReplace<
+  PageContextBuiltInClientWithClientRouting,
+  {
+    Page: React.FC;
+    pageProps?: Record<string, unknown>;
+  }
+>;
+
+export type PageClientRender = (ctx: PageContext) => void;
+
+export type PageServerRender = (ctx: PageContext) => {
+  documentHtml: unknown;
+  pageContext: {}; // TODO: extra context can be passed to client (e.g. document title)
+};
+
+//
+// utils
+//
+
+// cf. https://github.com/sindresorhus/type-fest/blob/1fce25cf8afadd4d4013e8f0ee64d045eda45cd7/source/except.d.ts
+type StrictOmit<T, K extends keyof T> = Omit<T, K>;
+
+type IntersectionReplace<T1, T2> = StrictOmit<T1, keyof T1 & keyof T2> & T2;


### PR DESCRIPTION
- a part of https://github.com/hi-ogawa/vite-fullstack-example/issues/7

It can be verified by seeing react-query's cache living through navigations.

## todo

- [x] review vite-plugin-ssr implementation
  - `<a>` click interception
  - hover prefetch
  - client render

## quick sketch of implementation

- grep `'clientRouting'`
- depending on the flag `hasClientRouting`, vite client entry switches either `client/entry.ts` or `client/router/entry.ts` (cf. `plugins/buildConfig.ts`)
  - https://github.com/brillout/vite-plugin-ssr/blob/ba35522e9d39239b724085ed15cf9ef4889cdd25/vite-plugin-ssr/node/plugin/plugins/buildConfig.ts#L86-L93
- in `router/entry.ts` (i.e. for client routing feature), it sets up global event handler e.g. 
  - `onLinkClick` (via `document.addEventListener('click', ...)`)
  - `onBrowserHistoryNavigation`
  -  etc..
- on such navigation event, it calls `fetchAndRender`, which does:
  - setup `PageContext` (e.g. `Page` component to render)
    - `getPageContext`, `getPageContextUponNavigation`, `loadPageFilesClientSide`, ...
  - `changeUrl` (mutate browser url via `window.history.pushState/replaceState`)
  - `executeOnClientRender` (client render hook)
  - `addLinkPrefetchHandlers`